### PR TITLE
Feature/equalizer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.1.0] - 2019-02-15
+## [2.2.0] - 2019-02-18
 
 ### Added
 
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `missingKeysTable` with new title
 - `wrongOrderKeysTable` with new title
 - `NO_LOCALE_FILES` error message
+
+## [2.1.0] - 2019-02-15
+
+### Added
+
+- Create `wrongOrderKeys` table
+
+### Changed
+
+- `table` to `missingKeysTable`
 
 ## [2.0.1] - 2018-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Updated `missingKeysTable` with new title
-- Updated `wrongOrderKeysTable` with new title
+- `missingKeysTable` with new title
+- `wrongOrderKeysTable` with new title
+- `NO_LOCALE_FILES` error message
 
 ## [2.0.1] - 2018-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `commander` for optional parameters
 - `build:watch` script for watching changes
 - `intl-equalizer --fix` command to fix order based on the referenceLocale
+- `extraKeysTable` result if another locale has more keys than the referenceLocale
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Create `wrongOrderKeys` table
+- `commander` for optional parameters
+- `build:watch` script for watching changes
+- `intl-equalizer --fix` command to fix order based on the referenceLocale
 
 ### Changed
 
-- `table` to `missingKeysTable`
+- Updated `missingKeysTable` with new title
+- Updated `wrongOrderKeysTable` with new title
 
 ## [2.0.1] - 2018-12-19
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ Or via npm:
 > `referenceLocale` default value is `'en'`
 
 > `localeDirectory` default value is `'/messages'`
+
+# Optional Commands
+
+## Fix
+
+Command to fix the order of the locale keys based on the `referenceLocale`
+
+```
+intl-equalizer --fix
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/intl-equalizer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "linter for locale json files",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env NODE_ENV=test jest",
     "jest": "cross-env NODE_ENV=test jest --watch --verbose --coverage=false",
     "build": "babel ./src --ignore */test,*/__mocks__ -d dist",
+    "build:watch": "watch 'npm run build' src",
     "demo-run": "npm run build && node ./dist/index.js",
     "prepublishOnly": "npm run build",
     "postreleasy": "npm publish"
@@ -69,6 +70,7 @@
   "dependencies": {
     "cli-table2": "^0.2.0",
     "diff": "^4.0.1",
+    "commander": "^2.19.0",
     "util": "^0.11.0"
   }
 }

--- a/src/configure.js
+++ b/src/configure.js
@@ -1,6 +1,6 @@
 import path from 'path'
 
-export function configure() {
+export default function configure() {
   const packageJson = require(path.join(process.cwd(), 'package.json'))
 
   const referenceLocaleFromPackageJson =

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,7 +26,7 @@ export const MESSAGES = {
     localeLength,
   }) =>
     colors.red(
-      `❌ Error: Could not fix locale ${locale.toUpperCase()} due to difference in locale size. \n ${referenceLocale.toUpperCase()} has ${referenceLocaleLength} keys. Although ${locale.toUpperCase()} has ${localeLength} keys.`
+      `❌ Error: Couldn't fix locale ${locale.toUpperCase()} due to differences on locale size. \n ${referenceLocale.toUpperCase()} has ${referenceLocaleLength} keys. Although, ${locale.toUpperCase()} has ${localeLength} keys.`
     ),
   WRITING_LOCALE: locale =>
     colors.yellow(`✏️  Writing sorted keys to ${locale}.json`),

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,7 @@ export const MESSAGES = {
       `❌ Error: There are no locale files in "${pathName}. \n Only base locales are considered. (i.e. LOCALE.json)`
     ),
   NO_LOCALE_FOLDER: pathName =>
-    colors.red(`❌ Error: There is no locales folder in "${pathName}.`),
+    colors.red(`❌ Error: There are no locale files folder in "${pathName}.`),
   ERROR_NO_KEYS_LOCALE: locale =>
     colors.red(
       `❌ Error: Locale ${locale} is empty. Add some keys or delete it.`

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,13 +7,27 @@ export const ERRORS = {
 }
 
 export const MESSAGES = {
+  COULD_NOT_WRITE_JSON: locale =>
+    colors.red(`❌ Error: Could not write keys to ${locale}.json.`),
   NO_LOCALE_FILES: pathName =>
-    colors.red(`❌ Error: There are no locale files in "${pathName}."`),
+    colors.red(`❌ Error: There are no locale files in "${pathName}.`),
   NO_LOCALE_FOLDER: pathName =>
-    colors.red(`❌ Error: There is no locales folder in "${pathName}."`),
+    colors.red(`❌ Error: There is no locales folder in "${pathName}.`),
   ERROR_NO_KEYS_LOCALE: locale =>
     colors.red(
-      `❌ Error: Locale ${locale} is empty. Add some keys or delete it."`
+      `❌ Error: Locale ${locale} is empty. Add some keys or delete it.`
     ),
+  ERROR_COULD_NOT_FIX: ({
+    referenceLocale,
+    locale,
+    referenceLocaleLength,
+    localeLength,
+  }) =>
+    colors.red(
+      `❌ Error: Could not fix locale ${locale.toUpperCase()} due to difference in locale size. \n ${referenceLocale.toUpperCase()} has ${referenceLocaleLength} keys. Although ${locale.toUpperCase()} has ${localeLength} keys.`
+    ),
+  WRITING_LOCALE: locale =>
+    colors.yellow(`✏️  Writing sorted keys to ${locale}.json`),
   SUCCESS: colors.yellow('✨ All keys are perfectly localized!'),
+  SUCCESS_FIX: colors.yellow('✨ Finished fixing keys!'),
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,7 +10,9 @@ export const MESSAGES = {
   COULD_NOT_WRITE_JSON: locale =>
     colors.red(`❌ Error: Could not write keys to ${locale}.json.`),
   NO_LOCALE_FILES: pathName =>
-    colors.red(`❌ Error: There are no locale files in "${pathName}.`),
+    colors.red(
+      `❌ Error: There are no locale files in "${pathName}. \n Only base locales are considered. (i.e. LOCALE.json)`
+    ),
   NO_LOCALE_FOLDER: pathName =>
     colors.red(`❌ Error: There is no locales folder in "${pathName}.`),
   ERROR_NO_KEYS_LOCALE: locale =>

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -54,10 +54,21 @@ export default function equalize({
         referenceOrder,
         languageOrder
       )
+
+      processedLanguages[language].extraKeys = getExtraKeys(
+        Object.keys(termsPerLanguage[referenceLocale]),
+        Object.keys(termsPerLanguage[language])
+      )
     })
   })
 
   return processedLanguages
+}
+
+function getExtraKeys(referenceKeys, currentLanguageKeys) {
+  return currentLanguageKeys.filter(
+    key => !referenceKeys.some(currKey => currKey === key)
+  )
 }
 
 function getCorrectLines(referenceOrder, languageOrder) {

--- a/src/equalizer.js
+++ b/src/equalizer.js
@@ -1,5 +1,3 @@
-import fs from 'fs'
-import path from 'path'
 import { ERRORS } from './constants'
 import fileReader from './fileReader'
 import { diffArrays } from 'diff'

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 import { ERRORS, MESSAGES } from './constants'
 
-export function throwError(error, data) {
+export default function throwError(error, data) {
   switch (error) {
     case ERRORS.ERROR_NO_LOCALE_FILES: {
       console.error(MESSAGES.NO_LOCALE_FILES(data))

--- a/src/extraKeysTable.js
+++ b/src/extraKeysTable.js
@@ -1,6 +1,5 @@
 import Table from 'cli-table2'
 import colors from 'colors/safe'
-import { MESSAGES } from './constants'
 
 export default function createTable(result, referenceLocale) {
   const table = new Table({
@@ -23,10 +22,10 @@ export default function createTable(result, referenceLocale) {
     },
     head: [
       {
-        colSpan: 4,
+        colSpan: 2,
         hAlign: 'center',
         content: colors.yellow(
-          `KEYS WITH DIFFERENT ORDER \n Run 'intl-equalizer --fix' to fix the order of the keys.`
+          `EXTRA KEYS \n These keys are missing from the reference locale.`
         ),
       },
     ],
@@ -34,7 +33,7 @@ export default function createTable(result, referenceLocale) {
 
   table.push([
     {
-      colSpan: 4,
+      colSpan: 2,
       hAlign: 'center',
       content: colors.yellow(
         `REFERENCE LOCALE: ${referenceLocale.toUpperCase()}`
@@ -44,8 +43,7 @@ export default function createTable(result, referenceLocale) {
 
   table.push([
     { hAlign: 'center', content: colors.yellow('LOCALE') },
-    { hAlign: 'center', content: colors.yellow('KEY') },
-    { hAlign: 'center', content: colors.yellow('CURRENT LINE') },
+    { hAlign: 'center', content: colors.yellow('EXTRA KEYS') },
   ])
 
   Object.keys(result).forEach(countryName => {
@@ -53,13 +51,8 @@ export default function createTable(result, referenceLocale) {
 
     const country = countryName.toUpperCase()
 
-    result[countryName].wrongOrderKeys.forEach(currentKey => {
-      table.push([
-        country,
-        currentKey.key,
-        currentKey.wrongLine,
-        currentKey.correctLine,
-      ])
+    result[countryName].extraKeys.forEach(currentKey => {
+      table.push([country, currentKey])
     })
   })
 

--- a/src/fileWriter.js
+++ b/src/fileWriter.js
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import { MESSAGES } from './constants'
+
+export default function writeFile({
+  sortedLanguages,
+  failedSortLanguages,
+  locales,
+  localesDirectory,
+  referenceLocale,
+}) {
+  locales.forEach(locale => {
+    if (
+      locale === referenceLocale ||
+      failedSortLanguages.find(failedLocale => failedLocale === locale)
+    ) {
+      return
+    }
+
+    const content = JSON.stringify(sortedLanguages[locale], null, 2)
+
+    try {
+      console.log(MESSAGES.WRITING_LOCALE(locale))
+      fs.writeFileSync(`${localesDirectory}/${locale}.json`, content, 'utf8')
+    } catch (err) {
+      console.error(err)
+      console.log(MESSAGES.COULD_NOT_WRITE_JSON(locale))
+      process.exit(1)
+    }
+  })
+}

--- a/src/fix.js
+++ b/src/fix.js
@@ -1,0 +1,72 @@
+import { getAvailableLanguages } from './languages'
+import configure from './configure'
+import throwError from './errors'
+import fileReader from './fileReader'
+import fileWriter from './fileWriter'
+import { MESSAGES } from './constants'
+
+export default function fix() {
+  const config = configure()
+
+  const languages = getAvailableLanguages(config.localesDirectory)
+
+  if (languages.error) {
+    throwError(languages.error, config.localesDirectory)
+  }
+
+  const termsPerLanguage = fileReader({
+    languages,
+    localesDirectory: config.localesDirectory,
+  })
+
+  const failedSortLanguages = []
+
+  const sortedLanguages = languages.reduce((accLanguages, locale) => {
+    const localeKeysLength = Object.keys(termsPerLanguage[locale]).length
+    const referenceLocaleKeysLength = Object.keys(
+      termsPerLanguage[config.referenceLocale]
+    ).length
+
+    if (localeKeysLength !== referenceLocaleKeysLength) {
+      console.log(
+        MESSAGES.ERROR_COULD_NOT_FIX({
+          referenceLocale: config.referenceLocale,
+          locale,
+          referenceLocaleLength: referenceLocaleKeysLength,
+          localeLength: localeKeysLength,
+        })
+      )
+      failedSortLanguages.push(locale)
+      return {
+        ...accLanguages,
+        [locale]: termsPerLanguage[locale],
+      }
+    }
+
+    const sortedLanguage = Object.keys(
+      termsPerLanguage[config.referenceLocale]
+    ).reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: termsPerLanguage[locale][key],
+      }),
+      {}
+    )
+
+    return {
+      ...accLanguages,
+      [locale]: sortedLanguage,
+    }
+  }, {})
+
+  fileWriter({
+    sortedLanguages,
+    failedSortLanguages,
+    locales: languages,
+    localesDirectory: config.localesDirectory,
+    referenceLocale: config.referenceLocale,
+  })
+
+  console.log(MESSAGES.SUCCESS_FIX)
+  process.exit(0)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,13 @@ import commander from 'commander'
 import start from './start'
 import fix from './fix'
 
-commander.command('fix').action(fix)
+commander
+  .option('-f, --fix')
+  .parse(process.argv)
 
-commander.parse(process.argv)
+if (commander.fix) {
+  fix()
+}
 
 if (commander.args.length < 1) {
   start()

--- a/src/index.js
+++ b/src/index.js
@@ -1,47 +1,12 @@
 #!/usr/bin/env node
-import equalize from './equalizer'
-import { configure } from './configure'
-import { throwError } from './errors'
-import { getAvailableLanguages } from './languages'
-import { MESSAGES } from './constants'
-import createMissingKeysTable from './missingKeysTable'
-import createWrongOrderKeysTable from './wrongOrderKeysTable'
+import commander from 'commander'
+import start from './start'
+import fix from './fix'
 
-const config = configure()
+commander.command('fix').action(fix)
 
-const languages = getAvailableLanguages(config.localesDirectory)
+commander.parse(process.argv)
 
-if (languages.error) {
-  throwError(languages.error, config.localesDirectory)
+if (commander.args.length < 1) {
+  start()
 }
-
-const result = equalize({
-  languages,
-  localesDirectory: config.localesDirectory,
-  referenceLocale: config.referenceLocale,
-})
-
-if (result.error) {
-  throwError(result.error.code, result.error.data)
-}
-
-const hasMissingTerms = languages.some(
-  language => result[language].missingKeys.length !== 0
-)
-
-if (hasMissingTerms) {
-  createMissingKeysTable(result, config.referenceLocale)
-  process.exit(1)
-}
-
-const hasWrongOrderKeys = languages.some(
-  language => result[language].wrongOrderKeys.length !== 0
-)
-
-if (hasWrongOrderKeys) {
-  createWrongOrderKeysTable(result, config.referenceLocale)
-  process.exit(1)
-}
-
-console.log(MESSAGES.SUCCESS)
-process.exit(0)

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 import commander from 'commander'
+
 import start from './start'
 import fix from './fix'
 
-commander
-  .option('-f, --fix')
-  .parse(process.argv)
+commander.option('-f, --fix').parse(process.argv)
 
 if (commander.fix) {
   fix()

--- a/src/missingKeysTable.js
+++ b/src/missingKeysTable.js
@@ -24,12 +24,20 @@ export default function createTable(result, referenceLocale) {
       {
         colSpan: 3,
         hAlign: 'center',
-        content: colors.yellow(
-          `REFERENCE LOCALE: ${referenceLocale.toUpperCase()}`
-        ),
+        content: colors.yellow(`MISSING KEYS}`),
       },
     ],
   })
+
+  table.push([
+    {
+      colSpan: 3,
+      hAlign: 'center',
+      content: colors.yellow(
+        `REFERENCE LOCALE: ${referenceLocale.toUpperCase()}`
+      ),
+    },
+  ])
 
   table.push([
     { hAlign: 'center', content: colors.yellow('LOCALE') },

--- a/src/start.js
+++ b/src/start.js
@@ -5,6 +5,7 @@ import { getAvailableLanguages } from './languages'
 import { MESSAGES } from './constants'
 import createMissingKeysTable from './missingKeysTable'
 import createWrongOrderKeysTable from './wrongOrderKeysTable'
+import createExtraKeysTable from './extraKeysTable'
 
 function start() {
   const config = configure()
@@ -23,6 +24,15 @@ function start() {
 
   if (result.error) {
     throwError(result.error.code, result.error.data)
+  }
+
+  const hasExtraKeys = languages.some(
+    language => result[language].extraKeys.length !== 0
+  )
+
+  if (hasExtraKeys) {
+    createExtraKeysTable(result, config.referenceLocale)
+    process.exit(1)
   }
 
   const hasMissingTerms = languages.some(

--- a/src/start.js
+++ b/src/start.js
@@ -1,0 +1,50 @@
+import equalize from './equalizer'
+import configure from './configure'
+import throwError from './errors'
+import { getAvailableLanguages } from './languages'
+import { MESSAGES } from './constants'
+import createMissingKeysTable from './missingKeysTable'
+import createWrongOrderKeysTable from './wrongOrderKeysTable'
+
+function start() {
+  const config = configure()
+
+  const languages = getAvailableLanguages(config.localesDirectory)
+
+  if (languages.error) {
+    throwError(languages.error, config.localesDirectory)
+  }
+
+  const result = equalize({
+    languages,
+    localesDirectory: config.localesDirectory,
+    referenceLocale: config.referenceLocale,
+  })
+
+  if (result.error) {
+    throwError(result.error.code, result.error.data)
+  }
+
+  const hasMissingTerms = languages.some(
+    language => result[language].missingKeys.length !== 0
+  )
+
+  if (hasMissingTerms) {
+    createMissingKeysTable(result, config.referenceLocale)
+    process.exit(1)
+  }
+
+  const hasWrongOrderKeys = languages.some(
+    language => result[language].wrongOrderKeys.length !== 0
+  )
+
+  if (hasWrongOrderKeys) {
+    createWrongOrderKeysTable(result, config.referenceLocale)
+    process.exit(1)
+  }
+
+  console.log(MESSAGES.SUCCESS)
+  process.exit(0)
+}
+
+export default start

--- a/src/wrongOrderKeysTable.js
+++ b/src/wrongOrderKeysTable.js
@@ -1,5 +1,6 @@
 import Table from 'cli-table2'
 import colors from 'colors/safe'
+import { MESSAGES } from './constants';
 
 export default function createTable(result, referenceLocale) {
   const table = new Table({
@@ -24,7 +25,7 @@ export default function createTable(result, referenceLocale) {
       {
         colSpan: 4,
         hAlign: 'center',
-        content: colors.yellow(`KEYS WITH DIFFERENT ORDER`),
+        content: colors.yellow(`KEYS WITH DIFFERENT ORDER \n Run 'intl-equalizer --fix' to fix the order of the keys.`),
       },
     ],
   })

--- a/src/wrongOrderKeysTable.js
+++ b/src/wrongOrderKeysTable.js
@@ -24,12 +24,20 @@ export default function createTable(result, referenceLocale) {
       {
         colSpan: 4,
         hAlign: 'center',
-        content: colors.yellow(
-          `REFERENCE LOCALE: ${referenceLocale.toUpperCase()}`
-        ),
+        content: colors.yellow(`KEYS WITH DIFFERENT ORDER`),
       },
     ],
   })
+
+  table.push([
+    {
+      colSpan: 4,
+      hAlign: 'center',
+      content: colors.yellow(
+        `REFERENCE LOCALE: ${referenceLocale.toUpperCase()}`
+      ),
+    },
+  ])
 
   table.push([
     { hAlign: 'center', content: colors.yellow('LOCALE') },

--- a/src/wrongOrderKeysTable.js
+++ b/src/wrongOrderKeysTable.js
@@ -46,6 +46,7 @@ export default function createTable(result, referenceLocale) {
     { hAlign: 'center', content: colors.yellow('LOCALE') },
     { hAlign: 'center', content: colors.yellow('KEY') },
     { hAlign: 'center', content: colors.yellow('CURRENT LINE') },
+    { hAlign: 'center', content: colors.yellow('CORRECT LINE') },
   ])
 
   Object.keys(result).forEach(countryName => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,7 +1468,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0:
+commander@^2.11.0, commander@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==


### PR DESCRIPTION
#### What is the purpose of this pull request?
### Added
- `commander` for optional parameters
- `build:watch` script for watching changes
- `intl-equalizer --fix` command to fix order based on the referenceLocale
- `extraKeysTable` result if another locale has more keys than the referenceLocale

### Changed

- `missingKeysTable` with new title
- `wrongOrderKeysTable` with new title
- `NO_LOCALE_FILES` error message

#### Screenshots or example usage
|New Table Title|
|-------|
|<img width="535" alt="screen shot 2019-02-15 at 17 46 52" src="https://user-images.githubusercontent.com/5608421/52880703-d22c4100-3149-11e9-84b4-2f5dbfcbdd64.png">|

| `intl-equalizer --fix` Command|
|-------|
|<img width="799" alt="screen shot 2019-01-31 at 00 04 55" src="https://user-images.githubusercontent.com/5608421/52025586-04a03200-24ec-11e9-9e38-f5c13c167145.png">|

|Extra Keys Table|
|-------|
|<img width="610" alt="screen shot 2019-02-15 at 17 38 29" src="https://user-images.githubusercontent.com/5608421/52880601-85e10100-3149-11e9-8cfd-f937909f4fc1.png">|


#### Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Requires change to documentation, which has been updated accordingly.
