### PR TITLE
Prevent option '--all' to always return an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- Fix `--all` option always return error
+
 ## [2.5.0] - 2020-10-14
 
 ### Added

--- a/src/start.js
+++ b/src/start.js
@@ -97,7 +97,7 @@ function start(options = {}) {
 
   if (
     options.all &&
-    (hasExtraKeys ||
+    (hasExtraKeys(languages, result) ||
       hasMissingTerms ||
       hasWrongOrderKeys ||
       hasExtraKeysRegion ||


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent option '--all' to always return an error

#### What problem is this solving?
Even when files inside messages don't have an error, using the command with the `--all` option is returning an error

#### How should this be manually tested?
1. Fix all messages errors and run the command `yarn demo-run -- --all`
2. Check if it returns a successful response

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
