### PR TITLE
Change the behavior when running the script with an invalid option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 - Fix `--all` option always return error
-- Fix when pass an invalid option to run the command like without any option
+- Fix the behavior when running the script with an invalid option
 
 ## [2.5.0] - 2020-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixed
 - Fix `--all` option always return error
+- Fix when pass an invalid option to run the command like without any option
 
 ## [2.5.0] - 2020-10-14
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,12 @@ commander
   .option('-a, --all', 'Show all errors.')
   .parse(process.argv)
 
+const isValidOption = () => {
+  const options = commander.opts() || {}
+
+  return Object.values(options).some((value) => value)
+}
+
 if (commander.fix) {
   fix()
 }
@@ -17,6 +23,6 @@ if (commander.all) {
   start({ all: true })
 }
 
-if (commander.args.length < 1) {
+if (!isValidOption()) {
   start()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the behavior when running the script with an invalid option

#### What problem is this solving?
When we use intl-equalizer on lint-staged, by default, it passes the path of staged files as argv for each command on the array of configuration, in that case, the command doesn't return an error or a success, just end without response. The same behavior occurs with any attempt contains unknown options.

#### How should this be manually tested?
1. Try to run the command
`yarn demo-run abc`
2. The expected result is to return the errors on messages files

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
